### PR TITLE
Add keygen methods for hmac and aes in web context.

### DIFF
--- a/cryptography/lib/src/cryptography/hash_algorithm.dart
+++ b/cryptography/lib/src/cryptography/hash_algorithm.dart
@@ -63,6 +63,11 @@ abstract class HashAlgorithm {
   ///   * "sha256"
   String get name;
 
+  /// Generates a secret key for keyed hash functions.
+  Future<SecretKey> newHashKey() async {
+    return SecretKey.randomBytes(hashLengthInBytes);
+  }
+
   /// Calculates hash for the argument.
   Future<Hash> hash(List<int> input) async {
     return Future<Hash>.value(await hashSync(input));

--- a/cryptography/lib/src/cryptography/web_crypto/bindings.dart
+++ b/cryptography/lib/src/cryptography/web_crypto/bindings.dart
@@ -68,6 +68,7 @@ class AesKeyGenParams {
 class Crypto {
   external factory Crypto._();
   external Subtle get subtle;
+  external Uint8List getRandomValues(Uint8List array);
 }
 
 @JS()

--- a/cryptography/lib/src/cryptography/web_crypto/bindings.dart
+++ b/cryptography/lib/src/cryptography/web_crypto/bindings.dart
@@ -128,7 +128,7 @@ class HmacKeyGenParams {
   external factory HmacKeyGenParams({
     @required String name,
     @required String hash,
-    @required int length,
+    int length,
   });
 }
 

--- a/cryptography/lib/src/cryptography/web_crypto/bindings.dart
+++ b/cryptography/lib/src/cryptography/web_crypto/bindings.dart
@@ -134,6 +134,16 @@ class HmacKeyGenParams {
 
 @JS()
 @anonymous
+class HmacImportParams {
+  external factory HmacImportParams({
+    @required String name,
+    @required String hash,
+    int length,
+  });
+}
+
+@JS()
+@anonymous
 class Jwk {
   external factory Jwk({
     String crv,

--- a/cryptography/lib/src/cryptography/web_crypto/impl/aes_cbc.dart
+++ b/cryptography/lib/src/cryptography/web_crypto/impl/aes_cbc.dart
@@ -23,6 +23,9 @@ class _WebAesCbcCipher extends _WebAesCipher {
   Cipher get dartImplementation => dart.dartAesCbc;
 
   @override
+  String get webName => 'AES-CBC';
+
+  @override
   Future<Uint8List> _decrypt(
     List<int> input, {
     @required SecretKey secretKey,

--- a/cryptography/lib/src/cryptography/web_crypto/impl/aes_ctr.dart
+++ b/cryptography/lib/src/cryptography/web_crypto/impl/aes_ctr.dart
@@ -23,6 +23,9 @@ class _WebAesCtrCipher extends _WebAesCipher {
   Cipher get dartImplementation => dart.dartAesCtr;
 
   @override
+  String get webName => 'AES-CTR';
+
+  @override
   Future<Uint8List> _decrypt(
     List<int> input, {
     @required SecretKey secretKey,

--- a/cryptography/lib/src/cryptography/web_crypto/impl/aes_gcm.dart
+++ b/cryptography/lib/src/cryptography/web_crypto/impl/aes_gcm.dart
@@ -23,6 +23,9 @@ class _WebAesGcmCipher extends _WebAesCipher {
   Cipher get dartImplementation => dart.dartAesGcm;
 
   @override
+  String get webName => 'AES-GCM';
+
+  @override
   Future<Uint8List> _decrypt(
     List<int> input, {
     @required SecretKey secretKey,

--- a/cryptography/lib/src/cryptography/web_crypto/impl/hashes.dart
+++ b/cryptography/lib/src/cryptography/web_crypto/impl/hashes.dart
@@ -58,6 +58,24 @@ class _WebHash extends HashAlgorithm {
   String get name => dartImplementation.name;
 
   @override
+  Future<SecretKey> newHashKey() async {
+    final jsCryptoKey = await js
+        .promiseToFuture<web_crypto.CryptoKey>(web_crypto.subtle.generateKey(
+      web_crypto.HmacKeyGenParams(
+        name: 'HMAC',
+        hash: webName,
+      ),
+      true,
+      ['sign', 'verify'],
+    ));
+
+    final jsRaw = await js.promiseToFuture<ByteBuffer>(
+        web_crypto.subtle.exportKey('raw', jsCryptoKey));
+
+    return SecretKey(jsRaw.asUint8List());
+  }
+
+  @override
   Future<Hash> hash(List<int> bytes) async {
     ArgumentError.checkNotNull(bytes);
     if (bytes.length < minLengthForWebCrypto) {

--- a/cryptography/pubspec.yaml
+++ b/cryptography/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cryptography
-version: 1.2.2
+version: 1.3.0
 homepage: https://github.com/dint-dev/cryptography
 description:
   Cryptographic algorithms for encryption, digital signatures, key agreement, authentication, and

--- a/cryptography/pubspec.yaml
+++ b/cryptography/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cryptography
-version: 1.2.1
+version: 1.2.2
 homepage: https://github.com/dint-dev/cryptography
 description:
   Cryptographic algorithms for encryption, digital signatures, key agreement, authentication, and


### PR DESCRIPTION
I'm adding methods to generate keys using the web crypto api for both aes (symmetric key) and hmac. I know we could have used the keygen function in secret key but that doesn't actually take advantage of the web crypto api while in the web context.

Once again, thank you for your work.