### PR TITLE
Fix JS interop CryptoKey class conflict

### DIFF
--- a/cryptography/lib/src/browser/javascript_bindings.dart
+++ b/cryptography/lib/src/browser/javascript_bindings.dart
@@ -17,8 +17,11 @@ library web_crypto_api;
 
 import 'dart:convert' show base64Url;
 import 'dart:typed_data';
+import 'dart:html' show CryptoKey;
 
 import 'package:js/js.dart';
+
+export 'dart:html' show CryptoKey;
 
 List<int>? base64UrlDecode(String? s) {
   if (s == null) {
@@ -182,19 +185,6 @@ class AesKeyGenParams {
     required String name,
     required int length,
   });
-}
-
-@JS('CryptoKey')
-class CryptoKey {
-  external factory CryptoKey._();
-
-  external dynamic get algorithm;
-
-  external bool get extractable;
-
-  external String get type;
-
-  external List<String> get usages;
 }
 
 @JS('CryptoKeyPair')


### PR DESCRIPTION
This PR fixes a build issue on the latest Flutter web dev channel release.

```
Compiling lib/main.dart for the Web...                          
Target dart2js failed: Exception: /opt/hostedtoolcache/flutter/1.26.0-17.1.pre-dev/x64/.pub-cache/hosted/pub.dartlang.org/cryptography-2.0.0-nullsafety.2/lib/src/browser/javascript_bindings.dart:188:7:
Error: JS interop class 'CryptoKey' conflicts with natively supported class 'CryptoKey' in 'dart:html'.
class CryptoKey ***
      ^
Error: Compilation failed.
```

It seems like the `dart:html` bindings [hasn't been changed in a while](https://github.com/dart-lang/sdk/blob/2ea318b540948b55306bf82fd34b2c84ec634f48/sdk/lib/html/dart2js/html_dart2js.dart#L3374) and dart2js has only just decided to start complaining recently meaning this should be safe to merge for older releases of Flutter too.