### PR TITLE
cryptography_flutter: Fix propagating error to Flutter + fix fallback to non-plugin encrypt/decrypt

### DIFF
--- a/cryptography_flutter/ios/Classes/SwiftCryptographyFlutterPlugin.swift
+++ b/cryptography_flutter/ios/Classes/SwiftCryptographyFlutterPlugin.swift
@@ -75,14 +75,14 @@ public class SwiftCryptographyFlutterPlugin: NSObject, FlutterPlugin {
             switch algorithm {
             case "AesGcm":
                 let symmetricKey = SymmetricKey(data: secretKey)
-                    let sealedBox = try AES.GCM.seal(
-                        clearText,
-                        using: symmetricKey,
-                        nonce: AES.GCM.Nonce(data: nonce))
-                    result([
-                        "cipherText": FlutterStandardTypedData(bytes: sealedBox.ciphertext),
-                        "mac": FlutterStandardTypedData(bytes: sealedBox.tag),
-                    ])
+                let sealedBox = try AES.GCM.seal(
+                    clearText,
+                    using: symmetricKey,
+                    nonce: AES.GCM.Nonce(data: nonce))
+                result([
+                    "cipherText": FlutterStandardTypedData(bytes: sealedBox.ciphertext),
+                    "mac": FlutterStandardTypedData(bytes: sealedBox.tag),
+                ])
                 return
                 
             case "Chacha20.poly1305Aead":

--- a/cryptography_flutter/ios/Classes/SwiftCryptographyFlutterPlugin.swift
+++ b/cryptography_flutter/ios/Classes/SwiftCryptographyFlutterPlugin.swift
@@ -26,26 +26,46 @@ public class SwiftCryptographyFlutterPlugin: NSObject, FlutterPlugin {
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         switch call.method {
         case "encrypt":
-            encrypt(call:call, result:result)
-            
+            propagateError(result: result){
+                try self.encrypt(call:call, result:result)
+            }
+
         case "decrypt":
-            decrypt(call:call, result:result)
+            propagateError(result: result){
+                try self.decrypt(call:call, result:result)
+            }
             
         case "Ecdsa.newKeyPair":
-            ecdsaNewKeyPair(call:call, result:result)
+            propagateError(result: result){
+                try self.ecdsaNewKeyPair(call:call, result:result)
+            }
             
         case "Ecdsa.sign":
-            ecdsaSign(call:call, result:result)
+            propagateError(result: result){
+                try self.ecdsaSign(call:call, result:result)
+            }
             
         case "Ecdsa.verify":
-            ecdsaVerify(call:call, result:result)
+            propagateError(result: result){
+                try self.ecdsaVerify(call:call, result:result)
+            }
             
         default:
             result(FlutterMethodNotImplemented)
         }
     }
+
+    func propagateError<T>(result: @escaping FlutterResult, fn: @escaping () throws -> T ){
+        do{
+            try fn()
+        }catch let error as NSError {
+            result(FlutterError(code: "CATCHED_ERROR", message:"\(error.domain), \(error.code), \(error.description)", details: nil))
+        }catch {
+            result(FlutterError(code: "CATCHED_ERROR", message:"\(error)", details: nil))
+        }
+    }
     
-    private func encrypt(call: FlutterMethodCall, result: @escaping FlutterResult) {
+    private func encrypt(call: FlutterMethodCall, result: @escaping FlutterResult) throws{
         let args = call.arguments as! [String: Any];
         let algorithm = args["algo"] as! String
         let clearText = [UInt8]((args["clearText"] as! FlutterStandardTypedData).data)
@@ -55,14 +75,14 @@ public class SwiftCryptographyFlutterPlugin: NSObject, FlutterPlugin {
             switch algorithm {
             case "AesGcm":
                 let symmetricKey = SymmetricKey(data: secretKey)
-                let sealedBox = try! AES.GCM.seal(
-                    clearText,
-                    using: symmetricKey,
-                    nonce: AES.GCM.Nonce(data: nonce))
-                result([
-                    "cipherText": FlutterStandardTypedData(bytes: sealedBox.ciphertext),
-                    "mac": FlutterStandardTypedData(bytes: sealedBox.tag),
-                ])
+                    let sealedBox = try AES.GCM.seal(
+                        clearText,
+                        using: symmetricKey,
+                        nonce: AES.GCM.Nonce(data: nonce))
+                    result([
+                        "cipherText": FlutterStandardTypedData(bytes: sealedBox.ciphertext),
+                        "mac": FlutterStandardTypedData(bytes: sealedBox.tag),
+                    ])
                 return
                 
             case "Chacha20.poly1305Aead":
@@ -81,10 +101,10 @@ public class SwiftCryptographyFlutterPlugin: NSObject, FlutterPlugin {
                 break
             }
         }
-        result("unsupported_algorithm")
+        result(FlutterError(code: "UNSUPPORTED_ALGORITHM", message:nil, details: nil))
     }
     
-    private func decrypt(call: FlutterMethodCall, result: @escaping FlutterResult) {
+    private func decrypt(call: FlutterMethodCall, result: @escaping FlutterResult) throws{
         let args = call.arguments as! [String: Any];
         let algorithm = args["algo"] as! String
         let cipherText = [UInt8]((args["cipherText"] as! FlutterStandardTypedData).data)
@@ -95,11 +115,11 @@ public class SwiftCryptographyFlutterPlugin: NSObject, FlutterPlugin {
             switch algorithm {
             case "AesGcm":
                 let symmetricKey = SymmetricKey(data: secretKey)
-                let sealedBox = try! AES.GCM.SealedBox(
+                let sealedBox = try AES.GCM.SealedBox(
                     nonce: AES.GCM.Nonce(data: nonce),
                     ciphertext: cipherText,
                     tag: mac)
-                let clearText = try! AES.GCM.open(sealedBox, using:symmetricKey)
+                let clearText = try AES.GCM.open(sealedBox, using:symmetricKey)
                 result([
                     "clearText": FlutterStandardTypedData(bytes: clearText),
                 ])
@@ -121,17 +141,17 @@ public class SwiftCryptographyFlutterPlugin: NSObject, FlutterPlugin {
                 break
             }
         }
-        result("unsupported_algorithm")
+        result(FlutterError(code: "UNSUPPORTED_ALGORITHM", message:nil, details: nil))
     }
     
-    private func ecdsaNewKeyPair(call: FlutterMethodCall, result: @escaping FlutterResult) {
+    private func ecdsaNewKeyPair(call: FlutterMethodCall, result: @escaping FlutterResult) throws {
         let args = call.arguments as! [String: Any];
         let curve = args["curve"] as! String
         let seed = [UInt8]((args["seed"] as! FlutterStandardTypedData).data)
         if #available(iOS 13.0, OSX 15.0, tvOS 13.0, watchOS 6.0, *) {
             switch curve {
             case "P-256":
-                let privateKey = try! P256.Signing.PrivateKey(rawRepresentation: seed)
+                let privateKey = try P256.Signing.PrivateKey(rawRepresentation: seed)
                 let publicKey = privateKey.publicKey
                 result([
                     "privateKey": FlutterStandardTypedData(bytes: privateKey.rawRepresentation),
@@ -140,7 +160,7 @@ public class SwiftCryptographyFlutterPlugin: NSObject, FlutterPlugin {
                 ])
                 return
             case "P-384":
-                let privateKey = try! P384.Signing.PrivateKey(rawRepresentation: seed)
+                let privateKey = try P384.Signing.PrivateKey(rawRepresentation: seed)
                 let publicKey = privateKey.publicKey
                 result([
                     "privateKey": FlutterStandardTypedData(bytes: privateKey.rawRepresentation),
@@ -149,7 +169,7 @@ public class SwiftCryptographyFlutterPlugin: NSObject, FlutterPlugin {
                 ])
                 return
             case "P-521":
-                let privateKey = try! P521.Signing.PrivateKey(rawRepresentation: seed)
+                let privateKey = try P521.Signing.PrivateKey(rawRepresentation: seed)
                 let publicKey = privateKey.publicKey
                 result([
                     "privateKey": FlutterStandardTypedData(bytes: privateKey.rawRepresentation),
@@ -161,11 +181,11 @@ public class SwiftCryptographyFlutterPlugin: NSObject, FlutterPlugin {
                 break;
             }
         }
-        result("unsupported_algorithm")
+        result(FlutterError(code: "UNSUPPORTED_ALGORITHM", message:nil, details: nil))
     }
     
     
-    private func ecdsaSign(call: FlutterMethodCall, result: @escaping FlutterResult) {
+    private func ecdsaSign(call: FlutterMethodCall, result: @escaping FlutterResult) throws {
         if #available(iOS 13.0, OSX 15.0, tvOS 13.0, watchOS 6.0, *) {
             let args = call.arguments as! [String: Any];
             let curve = args["curve"] as! String
@@ -173,22 +193,22 @@ public class SwiftCryptographyFlutterPlugin: NSObject, FlutterPlugin {
             let privateKeyBytes = [UInt8]((args["privateKey"] as! FlutterStandardTypedData).data)
             switch curve {
             case "P-256":
-                let privateKey = try! P256.Signing.PrivateKey(rawRepresentation: privateKeyBytes)
-                let signature = try! privateKey.signature(for: data)
+                let privateKey = try P256.Signing.PrivateKey(rawRepresentation: privateKeyBytes)
+                let signature = try privateKey.signature(for: data)
                 result([
                     "signature": FlutterStandardTypedData(bytes: signature.rawRepresentation),
                 ])
                 return
             case "P-384":
-                let privateKey = try! P384.Signing.PrivateKey(rawRepresentation: privateKeyBytes)
-                let signature = try! privateKey.signature(for: data)
+                let privateKey = try P384.Signing.PrivateKey(rawRepresentation: privateKeyBytes)
+                let signature = try privateKey.signature(for: data)
                 result([
                     "signature": FlutterStandardTypedData(bytes: signature.rawRepresentation),
                 ])
                 return
             case "P-521":
-                let privateKey = try! P521.Signing.PrivateKey(rawRepresentation: privateKeyBytes)
-                let signature = try! privateKey.signature(for: data)
+                let privateKey = try P521.Signing.PrivateKey(rawRepresentation: privateKeyBytes)
+                let signature = try privateKey.signature(for: data)
                 result([
                     "signature": FlutterStandardTypedData(bytes: signature.rawRepresentation),
                 ])
@@ -197,10 +217,10 @@ public class SwiftCryptographyFlutterPlugin: NSObject, FlutterPlugin {
                 break;
             }
         }
-        result("unsupported_algorithm")
+        result(FlutterError(code: "UNSUPPORTED_ALGORITHM", message:nil, details: nil))
     }
     
-    private func ecdsaVerify(call: FlutterMethodCall, result: @escaping FlutterResult) {
+    private func ecdsaVerify(call: FlutterMethodCall, result: @escaping FlutterResult) throws {
         if #available(iOS 13.0, OSX 15.0, tvOS 13.0, watchOS 6.0, *) {
             let args = call.arguments as! [String: Any];
             let curve = args["curve"] as! String
@@ -210,24 +230,24 @@ public class SwiftCryptographyFlutterPlugin: NSObject, FlutterPlugin {
             var ok = false
             switch curve {
             case "P-256":
-                let publicKey = try! P256.Signing.PublicKey(rawRepresentation: publicKeyBytes)
-                let signature = try! P256.Signing.ECDSASignature(rawRepresentation: signatureBytes)
+                let publicKey = try P256.Signing.PublicKey(rawRepresentation: publicKeyBytes)
+                let signature = try P256.Signing.ECDSASignature(rawRepresentation: signatureBytes)
                 ok = publicKey.isValidSignature(signature, for: data)
                 result([
                     "ok": ok,
                 ])
                 return
             case "P-384":
-                let publicKey = try! P384.Signing.PublicKey(rawRepresentation: publicKeyBytes)
-                let signature = try! P384.Signing.ECDSASignature(rawRepresentation: signatureBytes)
+                let publicKey = try P384.Signing.PublicKey(rawRepresentation: publicKeyBytes)
+                let signature = try P384.Signing.ECDSASignature(rawRepresentation: signatureBytes)
                 ok = publicKey.isValidSignature(signature, for: data)
                 result([
                     "ok": ok,
                 ])
                 return
             case "P-521":
-                let publicKey = try! P521.Signing.PublicKey(rawRepresentation: publicKeyBytes)
-                let signature = try! P521.Signing.ECDSASignature(rawRepresentation: signatureBytes)
+                let publicKey = try P521.Signing.PublicKey(rawRepresentation: publicKeyBytes)
+                let signature = try P521.Signing.ECDSASignature(rawRepresentation: signatureBytes)
                 ok = publicKey.isValidSignature(signature, for: data)
                 result([
                     "ok": ok,
@@ -237,6 +257,6 @@ public class SwiftCryptographyFlutterPlugin: NSObject, FlutterPlugin {
                 break
             }
         }
-        result("unsupported_algorithm")
+        result(FlutterError(code: "UNSUPPORTED_ALGORITHM", message:nil, details: nil))
     }
 }

--- a/cryptography_flutter/lib/src/cipher.dart
+++ b/cryptography_flutter/lib/src/cipher.dart
@@ -36,10 +36,6 @@ Future<List<int>> _decryptWithPlugin(
       'mac': Uint8List.fromList(secretBox.mac.bytes),
     },
   );
-  final error = result['error'];
-  if (error is String) {
-    throw StateError(error);
-  }
   return result['clearText'] as Uint8List;
 }
 
@@ -61,10 +57,6 @@ Future<SecretBox> _encryptWithPlugin(
       'nonce': Uint8List.fromList(nonce),
     },
   );
-  final error = result['error'];
-  if (error is String) {
-    throw StateError(error);
-  }
   final cipherText = result['cipherText'] as Uint8List;
   var mac = Mac.empty;
   if (result.containsKey('mac')) {
@@ -88,7 +80,7 @@ abstract class FlutterCipher extends DelegatingCipher {
   }) async {
     if (usePlugin) {
       try {
-        return _decryptWithPlugin(
+        return await _decryptWithPlugin(
           this,
           secretBox,
           secretKey: secretKey,
@@ -115,7 +107,7 @@ abstract class FlutterCipher extends DelegatingCipher {
   }) async {
     if (usePlugin) {
       try {
-        return _encryptWithPlugin(
+        return await _encryptWithPlugin(
           this,
           clearText,
           secretKey: secretKey,
@@ -163,7 +155,7 @@ abstract class FlutterStreamingCipher extends DelegatingStreamingCipher
   }) async {
     if (keyStreamIndex == 0 && usePlugin) {
       try {
-        return _decryptWithPlugin(
+        await _decryptWithPlugin(
           this,
           secretBox,
           secretKey: secretKey,
@@ -192,7 +184,7 @@ abstract class FlutterStreamingCipher extends DelegatingStreamingCipher
   }) async {
     if (keyStreamIndex == 0 && usePlugin) {
       try {
-        return _encryptWithPlugin(
+        return await _encryptWithPlugin(
           this,
           clearText,
           secretKey: secretKey,


### PR DESCRIPTION
There was an issue mainly on iOS that if any error occurred (wrong keys, file...), whole app crashed. Error cannot be catched in flutter. So I've fixed this by propagating these errors to flutter. 

Also there was an issue with fallback encrypt/decrypt to pure-dart-functions. There was missing 'await' to work as intended