### PR TITLE
Fix Ed25519 and X25519 JWK

### DIFF
--- a/jwk/lib/jwk.dart
+++ b/jwk/lib/jwk.dart
@@ -361,7 +361,7 @@ class Jwk {
           type: type,
         );
 
-      case 'OCP':
+      case 'OKP':
         if (crv == 'Ed25519') {
           final y = this.y!;
           return SimpleKeyPair.lazy(
@@ -414,7 +414,7 @@ class Jwk {
           type: type,
         );
 
-      case 'OCP':
+      case 'OKP':
         final type = const <String, KeyPairType>{
           'Ed25519': KeyPairType.ed25519,
           'X25519': KeyPairType.x25519,

--- a/jwk/lib/jwk.dart
+++ b/jwk/lib/jwk.dart
@@ -363,18 +363,18 @@ class Jwk {
 
       case 'OKP':
         if (crv == 'Ed25519') {
-          final y = this.y!;
+          final d = this.d!;
           return SimpleKeyPair.lazy(
             () async {
-              return Ed25519().newKeyPairFromSeed(y);
+              return Ed25519().newKeyPairFromSeed(d);
             },
           );
         }
         if (crv == 'X25519') {
-          final y = this.y!;
+          final d = this.d!;
           return SimpleKeyPair.lazy(
             () async {
-              return X25519().newKeyPairFromSeed(y);
+              return X25519().newKeyPairFromSeed(d);
             },
           );
         }

--- a/jwk/lib/jwk.dart
+++ b/jwk/lib/jwk.dart
@@ -542,9 +542,9 @@ class Jwk {
       }[keyPair.type];
       if (crv != null) {
         return Jwk(
-          kty: 'EC',
+          kty: 'OKP',
           crv: crv,
-          x: keyPair.bytes,
+          d: keyPair.bytes,
         );
       }
     } else if (keyPair is RsaKeyPairData) {
@@ -584,7 +584,7 @@ class Jwk {
       }[publicKey.type];
       if (crv != null) {
         return Jwk(
-          kty: 'EC',
+          kty: 'OKP',
           crv: crv,
           x: publicKey.bytes,
         );


### PR DESCRIPTION
I would like to merge this change because Ed25519 and X25519 JWK is wrong.

Please refer to [rfc8037#section-2](https://datatracker.ietf.org/doc/html/rfc8037#section-2).


### [Correct Example Ed25519 Private JWK](https://datatracker.ietf.org/doc/html/rfc8037#appendix-A.1)
```jsonc
{
  "kty" : "OKP",
  "crv" : "Ed25519",
  "d" : "nWGxne_9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A", // private key 
  "x" : "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo" // public key
}
```

### [Correct Example X25519 Public JWK](https://datatracker.ietf.org/doc/html/rfc8037#appendix-A.6)
```jsonc
{
  "kty" : "OKP",
  "crv" : "X25519",
  "kid" : "Bob", // optional
  "x" : "3p7bfXt9wbTTW2HC7OQ1Nz-DQ8hbeGdNrfx-FG-IK08" // public key
}
```

