### PR TITLE
Native decryption is ignored because of missing return

### DIFF
--- a/cryptography_flutter/lib/src/cipher.dart
+++ b/cryptography_flutter/lib/src/cipher.dart
@@ -150,7 +150,7 @@ abstract class FlutterStreamingCipher extends DelegatingStreamingCipher
   }) async {
     if (keyStreamIndex == 0 && usePlugin) {
       try {
-        await _decryptWithPlugin(
+        return await _decryptWithPlugin(
           this,
           secretBox,
           secretKey: secretKey,

--- a/cryptography_flutter/pubspec.yaml
+++ b/cryptography_flutter/pubspec.yaml
@@ -19,10 +19,6 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^1.0.4
 
-dependency_overrides:
-  cryptography:
-    path: ../cryptography
-
 flutter:
   plugin:
     platforms:


### PR DESCRIPTION
There is a missing return in the decrypt function in `cryptography_flutter`, which makes the data decrypted natively ignored.