### PR TITLE
Fix Ed25519 and X25519 JWK and the EC public key JWK

### DIFF
--- a/cryptography/lib/src/cryptography/simple_key_pair.dart
+++ b/cryptography/lib/src/cryptography/simple_key_pair.dart
@@ -51,10 +51,10 @@ abstract class SimpleKeyPair extends KeyPair {
 ///   * [X25519]
 @sealed
 class SimpleKeyPairData extends KeyPairData implements SimpleKeyPair {
-  /// Elliptic curve parameter `d`.
+  /// The private key
   final List<int> d;
 
-  /// Elliptic curve parameter `x`.
+  /// The public key
   final List<int> x;
 
   Future<SimplePublicKey>? _publicKey;

--- a/cryptography/lib/src/cryptography/simple_key_pair.dart
+++ b/cryptography/lib/src/cryptography/simple_key_pair.dart
@@ -50,27 +50,34 @@ abstract class SimpleKeyPair extends KeyPair {
 ///   * [Ed25519]
 ///   * [X25519]
 @sealed
-class SimpleKeyPairData implements KeyPairData, SimpleKeyPair {
-  final List<int> bytes;
+class SimpleKeyPairData extends KeyPairData implements SimpleKeyPair {
+  /// Elliptic curve parameter `d`.
+  final List<int> d;
 
-  @override
-  final KeyPairType type;
+  /// Elliptic curve parameter `x`.
+  final List<int> x;
 
-  final FutureOr<SimplePublicKey> _publicKey;
+  Future<SimplePublicKey>? _publicKey;
 
   SimpleKeyPairData(
-    this.bytes, {
-    required FutureOr<SimplePublicKey> publicKey,
-    required this.type,
-  }) : _publicKey = publicKey;
+    this.d,
+    this.x, {
+    required KeyPairType type,
+  }) : super(type: type);
+
+  get bytes => d;
 
   @override
-  int get hashCode => constantTimeBytesEquality.hash(bytes) ^ type.hashCode;
+  int get hashCode =>
+      constantTimeBytesEquality.hash(d) ^
+      constantTimeBytesEquality.hash(x) ^
+      type.hashCode;
 
   @override
   bool operator ==(other) =>
       other is SimpleKeyPairData &&
-      constantTimeBytesEquality.equals(bytes, other.bytes) &&
+      constantTimeBytesEquality.equals(d, other.x) &&
+      constantTimeBytesEquality.equals(x, other.d) &&
       type == other.type;
 
   @override
@@ -82,8 +89,11 @@ class SimpleKeyPairData implements KeyPairData, SimpleKeyPair {
   Future<List<int>> extractPrivateKeyBytes() => Future<List<int>>.value(bytes);
 
   @override
-  Future<SimplePublicKey> extractPublicKey() async {
-    return _publicKey;
+  Future<SimplePublicKey> extractPublicKey() {
+    return _publicKey ??= Future<SimplePublicKey>.value(SimplePublicKey(
+      x,
+      type: type,
+    ));
   }
 
   @override

--- a/cryptography/lib/src/cryptography/simple_public_key.dart
+++ b/cryptography/lib/src/cryptography/simple_public_key.dart
@@ -27,7 +27,7 @@ import 'package:meta/meta.dart';
 ///   * [X25519]
 @sealed
 class SimplePublicKey extends PublicKey implements Comparable<SimplePublicKey> {
-  /// Elliptic curve parameter `x`.
+  /// The public key
   final List<int> x;
 
   @override

--- a/cryptography/lib/src/cryptography/simple_public_key.dart
+++ b/cryptography/lib/src/cryptography/simple_public_key.dart
@@ -27,12 +27,15 @@ import 'package:meta/meta.dart';
 ///   * [X25519]
 @sealed
 class SimplePublicKey extends PublicKey implements Comparable<SimplePublicKey> {
-  final List<int> bytes;
+  /// Elliptic curve parameter `x`.
+  final List<int> x;
 
   @override
   final KeyPairType type;
 
-  SimplePublicKey(this.bytes, {required this.type});
+  SimplePublicKey(this.x, {required this.type});
+
+  get bytes => x;
 
   @override
   int get hashCode => const ListEquality<int>().hash(bytes) ^ type.hashCode;

--- a/cryptography/lib/src/dart/ed25519.dart
+++ b/cryptography/lib/src/dart/ed25519.dart
@@ -32,15 +32,16 @@ class DartEd25519 extends Ed25519 {
   KeyPairType get keyPairType => KeyPairType.ed25519;
 
   @override
-  Future<SimpleKeyPair> newKeyPairFromSeed(List<int> seed) {
+  Future<SimpleKeyPair> newKeyPairFromSeed(List<int> seed) async {
     if (seed.length != 32) {
       throw ArgumentError('Seed must have 32 bytes');
     }
-    return Future<SimpleKeyPairData>.value(SimpleKeyPairData(
+    SimplePublicKey publicKey = await _publicKey(seed);
+    return SimpleKeyPairData(
       List<int>.unmodifiable(seed),
+      List<int>.unmodifiable(publicKey.x),
       type: KeyPairType.ed25519,
-      publicKey: _publicKey(seed),
-    ));
+    );
   }
 
   // Compresses a point

--- a/cryptography/lib/src/dart/x25519.dart
+++ b/cryptography/lib/src/dart/x25519.dart
@@ -43,15 +43,15 @@ class DartX25519 extends X25519 with DartKeyExchangeAlgorithmMixin {
   KeyPairType get keyPairType => KeyPairType.x25519;
 
   @override
-  Future<SimpleKeyPair> newKeyPairFromSeed(List<int> seed) {
+  Future<SimpleKeyPair> newKeyPairFromSeed(List<int> seed) async {
     final modifiedBytes = DartX25519.modifiedPrivateKeyBytes(seed);
-    return Future<SimpleKeyPairData>.value(SimpleKeyPairData(
+    var publicKey = DartX25519._publicKey(modifiedBytes);
+
+    return SimpleKeyPairData(
       modifiedBytes,
-      publicKey: Future<SimplePublicKey>(
-        () => DartX25519._publicKey(modifiedBytes),
-      ),
+      publicKey.x,
       type: KeyPairType.x25519,
-    ));
+    );
   }
 
   @override

--- a/cryptography/test/simple_key_pair_test.dart
+++ b/cryptography/test/simple_key_pair_test.dart
@@ -18,34 +18,10 @@ import 'package:test/test.dart';
 void main() {
   group('SimpleKeyPairData:', () {
     test('"==" / hashCode', () {
-      final value = SimpleKeyPairData(
-        [1],
-        publicKey: Future<SimplePublicKey>.value(
-          SimplePublicKey([2], type: KeyPairType.ed25519),
-        ),
-        type: KeyPairType.ed25519,
-      );
-      final clone = SimpleKeyPairData(
-        [1],
-        publicKey: Future<SimplePublicKey>.value(
-          SimplePublicKey([2], type: KeyPairType.ed25519),
-        ),
-        type: KeyPairType.ed25519,
-      );
-      final other0 = SimpleKeyPairData(
-        [9999],
-        publicKey: Future<SimplePublicKey>.value(
-          SimplePublicKey([2], type: KeyPairType.ed25519),
-        ),
-        type: KeyPairType.ed25519,
-      );
-      final other1 = SimpleKeyPairData(
-        [1],
-        publicKey: Future<SimplePublicKey>.value(
-          SimplePublicKey([2], type: KeyPairType.ed25519),
-        ),
-        type: KeyPairType.x25519,
-      );
+      final value = SimpleKeyPairData([1], [2], type: KeyPairType.ed25519);
+      final clone = SimpleKeyPairData([1], [2], type: KeyPairType.ed25519);
+      final other0 = SimpleKeyPairData([9999], [2], type: KeyPairType.ed25519);
+      final other1 = SimpleKeyPairData([1], [2], type: KeyPairType.x25519);
 
       expect(value, clone);
       expect(value, isNot(other0));
@@ -57,13 +33,7 @@ void main() {
     });
 
     test('toString() shows only key type', () {
-      final value = SimpleKeyPairData(
-        [1],
-        publicKey: Future<SimplePublicKey>.value(
-          SimplePublicKey([2], type: KeyPairType.ed25519),
-        ),
-        type: KeyPairType.ed25519,
-      );
+      final value = SimpleKeyPairData([1], [2], type: KeyPairType.ed25519);
       expect(
         value.toString(),
         'SimpleKeyPairData(..., type: KeyPairType.ed25519)',
@@ -73,22 +43,10 @@ void main() {
 
   group('SimplePublicKey:', () {
     test('"==" / hashCode', () {
-      final value = SimplePublicKey(
-        [1],
-        type: KeyPairType.ed25519,
-      );
-      final clone = SimplePublicKey(
-        [1],
-        type: KeyPairType.ed25519,
-      );
-      final other0 = SimplePublicKey(
-        [9999],
-        type: KeyPairType.ed25519,
-      );
-      final other1 = SimplePublicKey(
-        [1],
-        type: KeyPairType.x25519,
-      );
+      final value = SimplePublicKey([1], type: KeyPairType.ed25519);
+      final clone = SimplePublicKey([1], type: KeyPairType.ed25519);
+      final other0 = SimplePublicKey([9999], type: KeyPairType.ed25519);
+      final other1 = SimplePublicKey([1], type: KeyPairType.x25519);
 
       expect(value, clone);
       expect(value, isNot(other0));
@@ -100,10 +58,7 @@ void main() {
     });
 
     test('toString()', () {
-      final value = SimplePublicKey(
-        [1, 2],
-        type: KeyPairType.ed25519,
-      );
+      final value = SimplePublicKey([1, 2], type: KeyPairType.ed25519);
       expect(value.toString(),
           'SimplePublicKey([1,2], type: KeyPairType.ed25519)');
     });

--- a/jwk/lib/jwk.dart
+++ b/jwk/lib/jwk.dart
@@ -370,9 +370,10 @@ class Jwk {
           throw StateError('Unsupported "crv": "$crv"');
         }
         return SimpleKeyPairData(
-            List<int>.unmodifiable(d ?? const <int>[]),
-            List<int>.unmodifiable(x ?? const <int>[]),
-            type: type);
+          List<int>.unmodifiable(d ?? const <int>[]),
+          List<int>.unmodifiable(x ?? const <int>[]),
+          type: type,
+        );
 
       case 'RSA':
         return RsaKeyPairData(
@@ -570,6 +571,7 @@ class Jwk {
           kty: 'EC',
           crv: crv,
           x: publicKey.x,
+          y: publicKey.y,
         );
       }
     } else if (publicKey is SimplePublicKey) {

--- a/jwk/lib/jwk.dart
+++ b/jwk/lib/jwk.dart
@@ -361,24 +361,18 @@ class Jwk {
           type: type,
         );
 
-      case 'OCP':
-        if (crv == 'Ed25519') {
-          final y = this.y!;
-          return SimpleKeyPair.lazy(
-            () async {
-              return Ed25519().newKeyPairFromSeed(y);
-            },
-          );
+      case 'OKP':
+        final type = const <String, KeyPairType>{
+          'Ed25519': KeyPairType.ed25519,
+          'X25519': KeyPairType.x25519,
+        }[crv];
+        if (type == null) {
+          throw StateError('Unsupported "crv": "$crv"');
         }
-        if (crv == 'X25519') {
-          final y = this.y!;
-          return SimpleKeyPair.lazy(
-            () async {
-              return X25519().newKeyPairFromSeed(y);
-            },
-          );
-        }
-        throw StateError('Unsupported "crv": "$crv"');
+        return SimpleKeyPairData(
+            List<int>.unmodifiable(d ?? const <int>[]),
+            List<int>.unmodifiable(x ?? const <int>[]),
+            type: type);
 
       case 'RSA':
         return RsaKeyPairData(
@@ -414,7 +408,7 @@ class Jwk {
           type: type,
         );
 
-      case 'OCP':
+      case 'OKP':
         final type = const <String, KeyPairType>{
           'Ed25519': KeyPairType.ed25519,
           'X25519': KeyPairType.x25519,
@@ -542,9 +536,10 @@ class Jwk {
       }[keyPair.type];
       if (crv != null) {
         return Jwk(
-          kty: 'EC',
+          kty: 'OKP',
           crv: crv,
-          x: keyPair.bytes,
+          d: keyPair.d,
+          x: keyPair.x,
         );
       }
     } else if (keyPair is RsaKeyPairData) {
@@ -584,7 +579,7 @@ class Jwk {
       }[publicKey.type];
       if (crv != null) {
         return Jwk(
-          kty: 'EC',
+          kty: 'OKP',
           crv: crv,
           x: publicKey.bytes,
         );

--- a/jwk/test/jwk_test.dart
+++ b/jwk/test/jwk_test.dart
@@ -141,4 +141,86 @@ void main() {
       expect(jwkFromPublicKey.toJson(), json);
     });
   });
+
+  group('Ed25519 private key', () {
+    final json = <String, Object>{
+      'kty': 'OKP',
+      'crv': 'Ed25519',
+      'd': base64Url.encode([1]),
+      'x': base64Url.encode([2]),
+    };
+
+    test('fromJson / toJson', () {
+      final key = Jwk.fromJson(json);
+      expect(key.toJson(), json);
+    });
+
+    test('toKeyPair() / fromKeyPair()', () async {
+      final jwk = Jwk.fromJson(json);
+      final keyPair = jwk.toKeyPair();
+      final jwkFromKeyPair = Jwk.fromKeyPair(keyPair);
+      expect(jwkFromKeyPair.toJson(), json);
+    });
+  });
+
+  group('Ed25519 public key', () {
+    final json = <String, Object>{
+      'kty': 'OKP',
+      'crv': 'Ed25519',
+      'x': base64Url.encode([1]),
+    };
+
+    test('fromJson / toJson', () {
+      final key = Jwk.fromJson(json);
+      expect(key.toJson(), json);
+    });
+
+    test('toPublicKey() / fromPublicKey()', () {
+      final jwk = Jwk.fromJson(json);
+      final publicKey = jwk.toPublicKey()!;
+      final jwkFromPublicKey = Jwk.fromPublicKey(publicKey);
+      expect(jwkFromPublicKey.toJson(), json);
+    });
+  });
+
+  group('X25519 private key', () {
+    final json = <String, Object>{
+      'kty': 'OKP',
+      'crv': 'X25519',
+      'd': base64Url.encode([1]),
+      'x': base64Url.encode([2]),
+    };
+
+    test('fromJson / toJson', () {
+      final key = Jwk.fromJson(json);
+      expect(key.toJson(), json);
+    });
+
+    test('toKeyPair() / fromKeyPair()', () async {
+      final jwk = Jwk.fromJson(json);
+      final keyPair = jwk.toKeyPair();
+      final jwkFromKeyPair = Jwk.fromKeyPair(keyPair);
+      expect(jwkFromKeyPair.toJson(), json);
+    });
+  });
+
+  group('X25519 public key', () {
+    final json = <String, Object>{
+      'kty': 'OKP',
+      'crv': 'X25519',
+      'x': base64Url.encode([1]),
+    };
+
+    test('fromJson / toJson', () {
+      final key = Jwk.fromJson(json);
+      expect(key.toJson(), json);
+    });
+
+    test('toPublicKey() / fromPublicKey()', () {
+      final jwk = Jwk.fromJson(json);
+      final publicKey = jwk.toPublicKey()!;
+      final jwkFromPublicKey = Jwk.fromPublicKey(publicKey);
+      expect(jwkFromPublicKey.toJson(), json);
+    });
+  });
 }

--- a/jwk/test/jwk_test.dart
+++ b/jwk/test/jwk_test.dart
@@ -81,6 +81,7 @@ void main() {
       'crv': 'P-256',
       'kty': 'EC',
       'x': base64Url.encode([1]),
+      'y': base64Url.encode([2]),
     };
 
     test('fromJson / toJson', () {


### PR DESCRIPTION
This properly fixes the Ed25519 and X25519 JWK support and the EC public key JWK as well. Has unit tests. See #73

Is a breaking change since the `SimpleKeyPairData` constructor API has changed.