### PR TITLE
Add p256k key pair type

### DIFF
--- a/cryptography/lib/src/cryptography/key_pair_type.dart
+++ b/cryptography/lib/src/cryptography/key_pair_type.dart
@@ -35,6 +35,15 @@ class KeyPairType<S extends KeyPairData, P extends PublicKey> {
     webCryptoCurve: 'P-256',
   );
 
+  /// Key pair type for [Ecdh] and [Ecdsa] with P-256 curve.
+  ///
+  /// Keys of this type can be generated with [EcKeyPairGenerator].
+  static const KeyPairType p256k = KeyPairType<EcKeyPairData, EcPublicKey>._(
+    name: 'p256k',
+    ellipticBits: 256,
+    webCryptoCurve: 'P-256K',
+  );
+
   /// Key pair type for [Ecdh] and [Ecdsa] with P-384 curve.
   ///
   /// Keys of this type can be generated with [EcKeyPairGenerator].

--- a/jwk/lib/jwk.dart
+++ b/jwk/lib/jwk.dart
@@ -606,6 +606,7 @@ class Jwk {
     if (publicKey is EcPublicKey) {
       final crv = const <KeyPairType, String>{
         KeyPairType.p256: 'P-256',
+        KeyPairType.p256k: 'secp256k1',
         KeyPairType.p384: 'P-384',
         KeyPairType.p521: 'P-521',
       }[publicKey.type];

--- a/jwk/lib/jwk.dart
+++ b/jwk/lib/jwk.dart
@@ -369,6 +369,7 @@ class Jwk {
       case 'EC':
         final type = const <String, KeyPairType>{
           'P-256': KeyPairType.p256,
+          'secp256k1': KeyPairType.p256k,
           'P-384': KeyPairType.p384,
           'P-521': KeyPairType.p521,
         }[crv];
@@ -430,6 +431,7 @@ class Jwk {
       case 'EC':
         final type = const <String, KeyPairType>{
           'P-256': KeyPairType.p256,
+          'secp256k1': KeyPairType.p256k,
           'P-384': KeyPairType.p384,
           'P-521': KeyPairType.p521,
         }[crv];
@@ -560,6 +562,7 @@ class Jwk {
     if (keyPair is EcKeyPairData) {
       final crv = const <KeyPairType, String>{
         KeyPairType.p256: 'P-256',
+        KeyPairType.p256k: 'secp256k1',
         KeyPairType.p384: 'P-384',
         KeyPairType.p521: 'P-521',
       }[keyPair.type];


### PR DESCRIPTION
I want to add secp256k1 key pair type.


Please refer to [RFC8821](https://datatracker.ietf.org/doc/html/rfc8812#section-3.1).
