### PR TITLE
Fix Blake2b hashes with 64+ byte inputs 

### DIFF
--- a/cryptography/lib/src/dart/blake2b_impl_browser.dart
+++ b/cryptography/lib/src/dart/blake2b_impl_browser.dart
@@ -150,7 +150,6 @@ class Blake2bSink extends DartHashSink {
 
     final h = _hash;
     h.setAll(0, _initializationVector);
-    h.fillRange(_initializationVector.length, h.length, 0);
     h[0] ^= 0x01010000 ^ 64;
   }
 

--- a/cryptography/lib/src/dart/blake2b_impl_browser.dart
+++ b/cryptography/lib/src/dart/blake2b_impl_browser.dart
@@ -62,7 +62,7 @@ class Blake2bSink extends DartHashSink {
     14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3
   ];
 
-  final _hash = Uint32List(32);
+  final _hash = Uint32List(16);
 
   @override
   late final Uint8List hashBytes = Uint8List.view(
@@ -104,13 +104,13 @@ class Blake2bSink extends DartHashSink {
     var length = _length;
     for (var i = start; i < end; i++) {
       // Compress?
-      if (length % 64 == 0 && length > 0) {
+      if (length % 128 == 0 && length > 0) {
         _length = length;
         _compress(false);
       }
 
       // Set byte
-      bufferAsBytes[length % 64] = chunk[i];
+      bufferAsBytes[length % 128] = chunk[i];
 
       // Increment length
       length++;
@@ -133,8 +133,10 @@ class Blake2bSink extends DartHashSink {
 
     // Unfinished block?
     final length = _length;
-    for (var i = length % 64; i < 64; i++) {
-      _bufferAsBytes[i] = 0;
+    if (length == 0 || length % 128 != 0) {
+      for (var i = length % 128; i < 128; i++) {
+        _bufferAsBytes[i] = 0;
+      }
     }
     _compress(true);
   }

--- a/cryptography/lib/src/dart/blake2b_impl_vm.dart
+++ b/cryptography/lib/src/dart/blake2b_impl_vm.dart
@@ -43,7 +43,7 @@ class Blake2bSink extends DartHashSink {
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
     14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3
   ];
-  final _hash = Uint64List(16);
+  final _hash = Uint64List(8);
   final _bufferAsUint64List = Uint64List(16);
   int _length = 0;
   bool _isClosed = false;
@@ -84,13 +84,13 @@ class Blake2bSink extends DartHashSink {
     var length = _length;
     for (var i = start; i < end; i++) {
       // Compress?
-      if (length % 64 == 0 && length > 0) {
+      if (length % 128 == 0 && length > 0) {
         _length = length;
         _compress(false);
       }
 
       // Set byte
-      bufferAsBytes[length % 64] = chunk[i];
+      bufferAsBytes[length % 128] = chunk[i];
 
       // Increment length
       length++;
@@ -113,8 +113,10 @@ class Blake2bSink extends DartHashSink {
 
     // Unfinished block?
     final length = _length;
-    for (var i = length % 64; i < 64; i++) {
-      _bufferAsBytes[i] = 0;
+    if (length == 0 || length % 128 != 0) {
+      for (var i = length % 128; i < 128; i++) {
+        _bufferAsBytes[i] = 0;
+      }
     }
     _compress(true);
   }

--- a/cryptography/lib/src/dart/blake2b_impl_vm.dart
+++ b/cryptography/lib/src/dart/blake2b_impl_vm.dart
@@ -130,7 +130,6 @@ class Blake2bSink extends DartHashSink {
 
     final h = _hash;
     h.setAll(0, _initializationVector);
-    h.fillRange(_initializationVector.length, h.length, 0);
     h[0] ^= 0x01010000 ^ 64;
   }
 

--- a/cryptography/test/algorithms/blake2b_test.dart
+++ b/cryptography/test/algorithms/blake2b_test.dart
@@ -152,5 +152,83 @@ BA 80 A5 3F 98 1C 4D 0D 6A 27 97 B6 9F 12 F6 E9
         );
       }
     });
+    test('63 bytes input', () async {
+      final expectedBytes = hexToBytes(
+          '058460852577e7de15323b6dbfc3656b325dc67a608fa555cfd7694b64a3433d3088eb9572fca9b7e776801bf032f84e179dbec34361f5edb47128d0cf236459');
+      // hash()
+      {
+        final hash = await algorithm.hash(utf8.encode(
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit turpis.'));
+        expect(
+          hexFromBytes(hash.bytes),
+          hexFromBytes(expectedBytes),
+        );
+      }
+    });
+    test('64 bytes input', () async {
+      final expectedBytes = hexToBytes(
+          'fc32fd5f4a3c6859cb6779cb14b277dd8483ae6da7fb593b62c4387a3dfe0f22fe96592b1affc725c2fd37f8d09ed5d096af377bf3b2453746d4fa79906d3221');
+      // hash()
+      {
+        final hash = await algorithm.hash(utf8.encode(
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit aliquam.'));
+        expect(
+          hexFromBytes(hash.bytes),
+          hexFromBytes(expectedBytes),
+        );
+      }
+    });
+    test('65 bytes input', () async {
+      final expectedBytes = hexToBytes(
+          'c8fa7cb677e3331450b508a4920338719c36709acfb09b6f6cab2dc2bbef0d292caddf6c444b0245c9dcab77c2fddaef89176acebc4e684e3caf6e853d5ac3ed');
+      // hash()
+      {
+        final hash = await algorithm.hash(utf8.encode(
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit volutpat.'));
+        expect(
+          hexFromBytes(hash.bytes),
+          hexFromBytes(expectedBytes),
+        );
+      }
+    });
+    test('127 bytes input', () async {
+      final expectedBytes = hexToBytes(
+          '4b4f18b171f48aae4159ca84129d7d03bc36cd79d89157ac80e7fdc747754b361c3928ca246e925cedd5ef4712d2aa8f21b39953b724410239da00327a040a0f');
+      // hash()
+      {
+        final hash = await algorithm.hash(utf8.encode(
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris ullamcorper tellus risus, a dapibus sapien hendrerit eget eros.'));
+        expect(
+          hexFromBytes(hash.bytes),
+          hexFromBytes(expectedBytes),
+        );
+      }
+    });
+    test('128 bytes input', () async {
+      final expectedBytes = hexToBytes(
+          '7a5164b11f34301dc9a95b06f610d4b2fa6b7ccbe51112800e6db10890319a8fcda37ec4d50ea25001cf7b493946f2403579a852e6c44c573da3eab9bf2b0a38');
+      // hash()
+      {
+        final hash = await algorithm.hash(utf8.encode(
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce finibus arcu dui. Fusce sed sem lectus. Cras mi massa porta ante.'));
+        expect(
+          hexFromBytes(hash.bytes),
+          hexFromBytes(expectedBytes),
+        );
+      }
+    });
+    test('444 bytes input', () async {
+      final expectedBytes = hexToBytes(
+          '8c12a0cf10e32bd38c8f458f880986609895988b013b0ca6ecf76aeb3dab2bebe8123a64c9f777acfebcca240c57e2788301ce6ae3ce30d20518a2f8d4002e9c');
+      // hash()
+      {
+        final hash = await algorithm.hash(utf8.encode(
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus commodo, ante id consectetur mollis, urna felis rutrum sem, nec dictum magna ligula quis nisl. Donec varius tempus pharetra. Cras auctor molestie ornare. Cras vestibulum, nibh in tempus finibus, arcu est sagittis lectus, bibendum ullamcorper dolor sapien ac turpis. Nulla a commodo purus. Integer elit ipsum, mattis a egestas et, auctor quis diam. Curabitur placerat massa nam.'));
+        expect(
+          hexFromBytes(hash.bytes),
+          hexFromBytes(expectedBytes),
+        );
+      }
+    });
   });
 }


### PR DESCRIPTION
This fixes the incorrect hashes of Blake2b when 64 or more bytes were used as input.
Fixes #145 