### PR TITLE
Allow decrypting SecretBox with a missing Mac

### DIFF
--- a/cryptography/lib/src/dart/dart_cipher.dart
+++ b/cryptography/lib/src/dart/dart_cipher.dart
@@ -420,11 +420,11 @@ mixin DartCipherWithStateMixin implements StreamingCipher {
     );
     final clearText = await state.convert(
       secretBox.cipherText,
-      expectedMac: secretBox.mac,
+      expectedMac: secretBox.mac.bytes.isNotEmpty ? secretBox.mac : null,
       possibleBuffer: possibleBuffer,
       chunkSize: chunkSize,
     );
-    if (secretBox.mac != state.mac) {
+    if (secretBox.mac.bytes.isNotEmpty && secretBox.mac != state.mac) {
       throw SecretBoxAuthenticationError();
     }
     return clearText;
@@ -456,7 +456,7 @@ mixin DartCipherWithStateMixin implements StreamingCipher {
       secretBox.cipherText,
       possibleBuffer: possibleBuffer,
     );
-    if (secretBox.mac != state.mac) {
+    if (secretBox.mac.bytes.isNotEmpty && secretBox.mac != state.mac) {
       throw SecretBoxAuthenticationError();
     }
     return clearText;


### PR DESCRIPTION
This allows skipping the `Mac` check when decrypting a `SecretBox` in `DartCipher`.

In the project I am working on, I need to be able to decrypt with an empty `Mac` in the `SecretBox`. Other locations in the library allow skipping authentication checks and support  `null`.

