### PR TITLE
docs: AesGcm documentation

### DIFF
--- a/cryptography/lib/src/cryptography/algorithms.dart
+++ b/cryptography/lib/src/cryptography/algorithms.dart
@@ -54,7 +54,7 @@ import 'package:meta/meta.dart';
 ///
 ///   // Decrypt
 ///   final clearText = await algorithm.encrypt(
-///     secretBox,
+///     secretBox.cipherText,
 ///     secretKey: secretKey,
 ///   );
 ///   print('Cleartext: $clearText');


### PR DESCRIPTION
Thank you for this library.

While I was reading the doc and copy/pasting some examples I've noticed a small mistake in [AesGcm documentation](https://pub.dev/documentation/cryptography/latest/cryptography/AesGcm-class.html) 
