### PR TITLE
Fix: adds super.destroy() to SecretKeyData

### DIFF
--- a/cryptography/lib/src/cryptography/secret_key.dart
+++ b/cryptography/lib/src/cryptography/secret_key.dart
@@ -201,6 +201,7 @@ class SecretKeyData extends SecretKey {
   @override
   void destroy() {
     _bytes.destroy();
+    super.destroy();
   }
 
   @override


### PR DESCRIPTION
This PR:
- adds `super.destroy()` to `SecretKeyData` or otherwise the property `isDestroyed` doesn't get updated after calling `destroy()`