### PR TITLE
chore: update js to 0.7.1 (was 0.6.7)

### DIFF
--- a/cryptography/pubspec.yaml
+++ b/cryptography/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   collection: ^1.17.0
   crypto: ^3.0.3
   ffi: ^2.1.0
-  js: ^0.6.7
+  js: ^0.7.1
   meta: ^1.8.0
   typed_data: ^1.3.0
 


### PR DESCRIPTION
This PR updates the [js](https://pub.dev/packages/js) dependency to `v0.7.1` until the project gets ported to [dart:js_interop](https://api.flutter.dev/flutter/dart-js_interop/dart-js_interop-library.html).