### PR TITLE
Allow empty HMAC key (#176)

### DIFF
--- a/cryptography/lib/src/browser/hmac.dart
+++ b/cryptography/lib/src/browser/hmac.dart
@@ -66,13 +66,6 @@ class BrowserHmac extends Hmac {
 
   Future<web_crypto.CryptoKey> _jsCryptoKey(SecretKey secretKey) async {
     final secretKeyBytes = await secretKey.extractBytes();
-    if (secretKeyBytes.isEmpty) {
-      throw ArgumentError.value(
-        secretKey,
-        'secretKey',
-        'SecretKey bytes must be non-empty',
-      );
-    }
     return await web_crypto.importKeyWhenRaw(
       web_crypto.jsUint8ListFrom(secretKeyBytes),
       web_crypto.HmacImportParams(

--- a/cryptography/lib/src/dart/hmac.dart
+++ b/cryptography/lib/src/dart/hmac.dart
@@ -120,13 +120,6 @@ class _DartHmacSink extends MacSink with DartMacSinkMixin {
         'AAD is not supported by HMAC',
       );
     }
-    if (secretKey.bytes.isEmpty) {
-      throw ArgumentError.value(
-        secretKey,
-        'secretKey',
-        'Secret key must be non-empty',
-      );
-    }
     _isClosed = false;
     var hmacKey = secretKey.bytes;
     var eraseKey = false;


### PR DESCRIPTION
Empty HMAC key can be useful in some situations like HKDF. See #176 .