### PR TITLE
Fix browser X25519.newKeyPair()

### DIFF
--- a/cryptography/lib/src/browser/x25519.dart
+++ b/cryptography/lib/src/browser/x25519.dart
@@ -53,7 +53,7 @@ class BrowserX25519 extends X25519 {
         Uint8List.fromList(web_crypto.base64UrlDecode(jwk.x!.toDart)),
         type: KeyPairType.x25519,
       ),
-      type: KeyPairType.ed25519,
+      type: KeyPairType.x25519,
     );
   }
 

--- a/cryptography/lib/src/browser/x25519.dart
+++ b/cryptography/lib/src/browser/x25519.dart
@@ -47,7 +47,7 @@ class BrowserX25519 extends X25519 {
       }
       throw StateError('$runtimeType.newKeyPair(...) failed: $e');
     }
-    return SimpleKeyPairData(
+    final keyPair = SimpleKeyPairData(
       Uint8List.fromList(web_crypto.base64UrlDecode(jwk.d!.toDart)),
       publicKey: SimplePublicKey(
         Uint8List.fromList(web_crypto.base64UrlDecode(jwk.x!.toDart)),
@@ -55,6 +55,8 @@ class BrowserX25519 extends X25519 {
       ),
       type: KeyPairType.x25519,
     );
+    final seed = await keyPair.extractPrivateKeyBytes();
+    return newKeyPairFromSeed(seed);
   }
 
   @override


### PR DESCRIPTION
1. browser X25519.newKeyPair() now properly declare generated key as x25519 instead of ed25519 previously.
2. browser X25519.newKeyPair() now returns a properly clamped private key.

Resolves: #220 